### PR TITLE
Updated the README to contain actually functioning code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ type Result {
 Now, let's create a simple `GooglePubSub` instance:
 
 ```javascript
-import { GooglePubSub } from '@axelspringer/graphql-google-pubsub';
+import GooglePubSub from '@axelspringer/graphql-google-pubsub';
 const pubsub = new GooglePubSub();
 ```
 
@@ -92,7 +92,7 @@ export const resolvers = {
 ## Creating the Google PubSub Client
 
 ```javascript
-import { GooglePubSub } from '@axelspringer/graphql-google-pubsub';
+import GooglePubSub from '@axelspringer/graphql-google-pubsub';
 
 const pubSub = new GooglePubSub(options, topic2SubName, commonMessageHandler)
 ```


### PR DESCRIPTION
I updated the README to properly import `GooglePubSub` and not confuse future users. 

Using the code in the current README would give a 'library does not have an export named GooglePubSub' erorr. This is due to `GooglePubSub` being a default export rather than a 'named' export. 

