### PR TITLE
set GooglePubSub.pubSubClient to public

### DIFF
--- a/src/google-pubsub.ts
+++ b/src/google-pubsub.ts
@@ -117,7 +117,7 @@ export default class GooglePubSub implements PubSubEngine {
 
   private commonMessageHandler: CommonMessageHandler;
   private topic2SubName: Topic2SubName;
-  private pubSubClient: any; // Todo: type
+  public pubSubClient: any; // Todo: type
 
   // [subName: string, onMessage: Function]
   private clientId2GoogleSubNameAndClientCallback: { [clientId: number]: [string, Function] };


### PR DESCRIPTION
Hi, I'd like to use the pubSubClient connection outside of the GooglePubSub class. Would it be alright to set it public to use it?

I'd prefer to just piggyback off of the connection created with this library, than have to create my own PubSub object.