### PR TITLE
Add type to asyncIterator function

### DIFF
--- a/src/google-pubsub.ts
+++ b/src/google-pubsub.ts
@@ -110,7 +110,7 @@ export default class GooglePubSub implements PubSubEngine {
     delete this.clientId2GoogleSubNameAndClientCallback[subId];
   }
 
-  public asyncIterator<T>(topics: string | string[], options?) {
+  public asyncIterator<T>(topics: string | string[], options?): AsyncIterator<T> {
     return new PubSubAsyncIterator(this, topics, options);
   }
 


### PR DESCRIPTION
Hi, I added the AsyncIterator type to the `asyncIteractor` function to avoid implicitly defaulting to type `any`