### PR TITLE
Widen dependencies to allow @google-cloud/pubsub ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "integration": "mocha --reporter spec --full-trace ./dist/test/integration-tests.js"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^1.1.5",
+    "@google-cloud/pubsub": "^1.1.5 || ^2.0.0",
     "iterall": "^1.2.2",
     "graphql-subscriptions": "^1.1.0"
   },


### PR DESCRIPTION
Thanks for the package :)

None of the [breaking changes introduced in `@google-cloud/pubsub` 2.0.0](https://github.com/googleapis/nodejs-pubsub/blob/master/CHANGELOG.md#200-2020-05-20) have any impact on this package, so it's safe to widen this constraint.

This change allows consumers to use this package with the latest google libs.